### PR TITLE
fix: injected wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,16 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.mjs"
     }
   },
   "files": [
     "dist"
   ],
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -31,9 +32,9 @@
   "author": "Bitte Team",
   "license": "MIT",
   "dependencies": {
-    "@near-wallet-selector/core": "^8.9.16",
-    "@near-wallet-selector/wallet-utils": "^8.9.16",
-    "near-api-js": "^5.0.1"
+    "@near-wallet-selector/core": "^8.10.1",
+    "@near-wallet-selector/wallet-utils": "^8.10.1",
+    "near-api-js": "^5.1.1"
   },
   "devDependencies": {
     "tsup": "^8.3.5",

--- a/src/bitte-wallet.ts
+++ b/src/bitte-wallet.ts
@@ -5,12 +5,11 @@ import type {
   SignMessageParams,
   Transaction,
 } from "@near-wallet-selector/core";
- import { createAction } from "@near-wallet-selector/wallet-utils";
+import { createAction } from "@near-wallet-selector/wallet-utils";
 import { connect, keyStores, providers, transactions } from "near-api-js";
-import type { PublicKey } from "near-api-js/lib/utils";
-import { KeyPair, serialize } from "near-api-js/lib/utils";
+import type { PublicKey } from "near-api-js/lib/utils/index.js";
+import { KeyPair, serialize } from "near-api-js/lib/utils/index.js";
 import { WalletConfig, WalletMessage, WalletResponseData, WalletState } from "./types";
-import type { Transaction as WalletSelectorTransaction, Action as WalletSelectorAction } from "@near-wallet-selector/core";
 
 
 // Constants
@@ -218,7 +217,7 @@ const signUsingKeyPair = async (
 
 const requestSignTransactionsUrl = (
   config: WalletConfig,
-  txs:  Array<Transaction>
+  txs: Array<Transaction>
 ): string => {
   const newUrl = new URL(`${config.walletUrl}/sign-transaction`);
 

--- a/src/bitte-wallet.ts
+++ b/src/bitte-wallet.ts
@@ -20,13 +20,13 @@ const POLL_INTERVAL = 300;
 
 // State management
 const getInitialState = (): WalletState => ({
-  signedAccountId: localStorage.getItem("signedAccountId") || "",
-  functionCallKey: JSON.parse(localStorage.getItem("functionCallKey") || "null"),
+  signedAccountId: localStorage.getItem("bitte:signedAccountId") || "",
+  functionCallKey: JSON.parse(localStorage.getItem("bitte:functionCallKey") || "null"),
 });
 
 const saveState = (state: WalletState): void => {
-  localStorage.setItem("signedAccountId", state.signedAccountId);
-  localStorage.setItem("functionCallKey", JSON.stringify(state.functionCallKey));
+  localStorage.setItem("bitte:signedAccountId", state.signedAccountId);
+  localStorage.setItem("bitte:functionCallKey", JSON.stringify(state.functionCallKey));
 };
 
 // Create wallet configuration
@@ -220,8 +220,7 @@ const requestSignTransactionsUrl = (
   txs: Array<Transaction>
 ): string => {
   const newUrl = new URL(`${config.walletUrl}/sign-transaction`);
-
-  const stringifiedParam = JSON.stringify(txs);
+  const stringifiedParam = JSON.stringify(txs, (_, v) => typeof v === 'bigint' ? v.toString() : v);
   const urlParam = encodeURIComponent(stringifiedParam);
 
   newUrl.searchParams.set('transactions_data', urlParam);
@@ -266,9 +265,7 @@ const signAndSendTransaction = async (
     }
   }
 
-
   const tx = await completeTransaction(config, state, { receiverId, actions });
-
   const results = await signAndSendTransactionsPopUp(config, [tx as any]);
   return results[0];
 };

--- a/src/bitte-wallet.ts
+++ b/src/bitte-wallet.ts
@@ -216,7 +216,7 @@ const signAndSendTransactionsPopUp = async (
   const url = requestSignTransactionsUrl(config, txs);
   const txsHashes = (
     await handlePopupTransaction(config, url, (data) => data.transactionHashes)
-  )?.split(",");
+  )?.split("%2C");
 
   if (!txsHashes) {
     throw new Error("No transaction hashes received");

--- a/src/bitte-wallet.ts
+++ b/src/bitte-wallet.ts
@@ -152,26 +152,6 @@ const signMessage = async (
   });
 };
 
-const completeTransaction = async (
-  config: WalletConfig,
-  state: WalletState,
-  { receiverId, actions }: { receiverId: string; actions: Array<Action> }
-): Promise<transactions.Transaction> => {
-  // To create a transaction we need a recent block
-  const block = await config.provider.block({ finality: "final" });
-  const blockHash = serialize.base_decode(block.header.hash);
-
-  // create Transaction for the wallet
-  return transactions.createTransaction(
-    state.signedAccountId,
-    KeyPair.fromRandom("ed25519").getPublicKey(),
-    receiverId,
-    0,
-    actions.map((a) => createAction(a)),
-    Uint8Array.from(blockHash)
-  );
-};
-
 const storedKeyCanSign = (
   state: WalletState,
   receiverId: string,
@@ -265,8 +245,7 @@ const signAndSendTransaction = async (
     }
   }
 
-  const tx = await completeTransaction(config, state, { receiverId, actions });
-  const results = await signAndSendTransactionsPopUp(config, [tx as any]);
+  const results = await signAndSendTransactionsPopUp(config, [{ signerId: state.signedAccountId, receiverId, actions }]);
   return results[0];
 };
 

--- a/src/bitte-wallet.ts
+++ b/src/bitte-wallet.ts
@@ -6,9 +6,9 @@ import type {
   Transaction,
 } from "@near-wallet-selector/core";
 import { createAction } from "@near-wallet-selector/wallet-utils";
-import { connect, keyStores, providers, transactions } from "near-api-js";
+import { connect, keyStores, providers } from "near-api-js";
 import type { PublicKey } from "near-api-js/lib/utils/index.js";
-import { KeyPair, serialize } from "near-api-js/lib/utils/index.js";
+import { KeyPair } from "near-api-js/lib/utils/index.js";
 import { WalletConfig, WalletMessage, WalletResponseData, WalletState } from "./types";
 
 


### PR DESCRIPTION
I have changed a couple of things on the `bitte-ai/wallet` package:

1. Fixed on `package.json` some very small inconsistency when declaring what `cjs` and `esm` files are exported
2. I have included the `.js` extension on the `bitte-wallet.ts` imports [note bellow]
3. I fixed `signAndSendTransaction`, which was creating a `transaction` that the wallet does not need
  3.1. Removed `createTransaction` as it is not needed 
4. Changed the name of the `localStorage` keys, prepending `bitte:` to them, to avoid collisions with MyNearWallet
 
[note] In all honesty, I was expecting `tsup` to take care of this, but in the spirit of not changing the code much I have opted for the simplest solution.