### PR TITLE
fix: migrate storage from browser version

### DIFF
--- a/src/bitte-wallet.ts
+++ b/src/bitte-wallet.ts
@@ -343,6 +343,15 @@ const handlePopupTransaction = <T>(
 
 export const createBitteWalletConnector = (walletUrl: string, network: Network) => {
   const config = createWalletConfig(walletUrl, network);
+
+  // Transform from previous wallet version
+  const walletAuthKey = localStorage.getItem("mintbase-wallet_wallet_auth_key");
+  if (walletAuthKey) {
+    const { accountId } = JSON.parse(walletAuthKey) || {};
+    localStorage.setItem("bitte:signedAccountId", accountId);
+    localStorage.removeItem("mintbase-wallet_wallet_auth_key");
+  }
+
   let state = getInitialState();
 
   return {


### PR DESCRIPTION
When bitte-wallet was a browser wallet, it was storing the information on the logged-in account in localStorage under a specific key. When we migrated it to be an injected wallet, we stored the account information in a different storage key.

If an application migrates from wallet selector v8 to v9, users that are already logged-in end up in a weird state, in which the wallet selector detects the user was readily logged in, but cannot find the username, thus showing this screen:

![image](https://github.com/user-attachments/assets/0bb59d37-8bce-4fae-b77a-e0b399c719e4)

This PR transforms the old storage key into the new one, so the wallet selector can correctly detect which user is logged in.